### PR TITLE
Fixing Nightly Breakage

### DIFF
--- a/ws_rs_with_rocket/Cargo.lock
+++ b/ws_rs_with_rocket/Cargo.lock
@@ -89,7 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "chat_app_with_rust_by_steadylearner"
 version = "0.1.0"
 dependencies = [
- "rocket 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "rocket"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -539,31 +539,31 @@ dependencies = [
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pear 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_codegen 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_http 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_http 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "yansi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rocket_codegen"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "devise 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_http 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_http 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "yansi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rocket_http"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -714,6 +714,11 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "version_check"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,9 +848,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2c4db68a2e35f3497146b7e4563df7d4773a2433230c5e4b448328e31740458a"
-"checksum rocket 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "55b83fcf219c8b4980220231d5dd9eae167bdc63449fdab0a04b6c8b8cd361a8"
-"checksum rocket_codegen 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5549dc59a729fbd0e6f5d5de33ba136340228871633485e4946664d36289ffd7"
-"checksum rocket_http 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "abec045da00893bd4eef6084307a4bec0742278a7635a6a8b943da023202a5f7"
+"checksum rocket 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "42c1e9deb3ef4fa430d307bfccd4231434b707ca1328fae339c43ad1201cc6f7"
+"checksum rocket_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "79aa1366f9b2eccddc05971e17c5de7bb75a5431eb12c2b5c66545fd348647f4"
+"checksum rocket_http 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b1391457ee4e80b40d4b57fa5765c0f2836b20d73bcbee4e3f35d93cf3b80817"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "a72e9b96fa45ce22a4bc23da3858dfccfd60acd28a25bcd328a98fdd6bea43fd"
 "checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
@@ -866,6 +871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/ws_rs_with_rocket/Cargo.toml
+++ b/ws_rs_with_rocket/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 
 [dependencies]
 ws = "0.8.1"
-rocket = "0.4.1"
+rocket = "0.4.2"

--- a/ws_rs_with_rocket/Cargo.toml
+++ b/ws_rs_with_rocket/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 
 [dependencies]
 ws = "0.8.1"
-rocket = "0.4.2"
+rocket = "0.4.2" #this update from 0.4.1 fixed a compiler error

--- a/ws_rs_with_rocket/src/chat/ws_rs.rs
+++ b/ws_rs_with_rocket/src/chat/ws_rs.rs
@@ -21,7 +21,8 @@ struct Server {
 }
 
 impl Handler for Server {
-    fn on_request(&mut self, req: &Request) -> Result<Response> {
+    fn on_request(&mut self, req: &Request) -> Result<Response> { //Removed enclosing "()" from "Response"
+
         match req.resource() {
             "/ws" => {
                 // used once for const socket = new WebSocket("ws://" + window.location.host + "/ws");

--- a/ws_rs_with_rocket/src/chat/ws_rs.rs
+++ b/ws_rs_with_rocket/src/chat/ws_rs.rs
@@ -21,7 +21,7 @@ struct Server {
 }
 
 impl Handler for Server {
-    fn on_request(&mut self, req: &Request) -> Result<(Response)> {
+    fn on_request(&mut self, req: &Request) -> Result<Response> {
         match req.resource() {
             "/ws" => {
                 // used once for const socket = new WebSocket("ws://" + window.location.host + "/ws");

--- a/ws_rs_with_rocket/src/main.rs
+++ b/ws_rs_with_rocket/src/main.rs
@@ -1,7 +1,7 @@
 #![feature(
     proc_macro_hygiene,
     decl_macro,
-    custom_attribute,
+    register_attr,
     rustc_private,
     type_ascription
 )]

--- a/ws_rs_with_rocket/src/main.rs
+++ b/ws_rs_with_rocket/src/main.rs
@@ -1,7 +1,7 @@
 #![feature(
     proc_macro_hygiene,
     decl_macro,
-    register_attr,
+    register_attr, // Rust replaced the previous feature with this
     rustc_private,
     type_ascription
 )]

--- a/ws_rs_with_rocket/static/chat/node_modules/.yarn-integrity
+++ b/ws_rs_with_rocket/static/chat/node_modules/.yarn-integrity
@@ -1,5 +1,5 @@
 {
-  "systemParams": "linux-x64-72",
+  "systemParams": "darwin-x64-72",
   "modulesFolders": [
     "node_modules"
   ],


### PR DESCRIPTION
Hey there,

Thank you for your tutorials.  I'm really enjoying them.  I went through the process of testing this chat app here and one of the dependencies requires nightly rust, and the newest version had changed a few things.  Rocket wanted version 0.4.2 and rust changed out custom_attribute for register_attr in the newest update.  I tested the changes locally and figure it's a small update but hope it helps. :)